### PR TITLE
support native Set and Map values

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,22 @@
           seen.pop ();
         }
 
+      case '[object Set]':
+        seen.push (x);
+        try {
+          return 'new Set (' + show (Array.from (x.values ())) + ')';
+        } finally {
+          seen.pop ();
+        }
+
+      case '[object Map]':
+        seen.push (x);
+        try {
+          return 'new Map (' + show (Array.from (x.entries ())) + ')';
+        } finally {
+          seen.pop ();
+        }
+
       default:
         return String (x);
 

--- a/test/index.js
+++ b/test/index.js
@@ -99,6 +99,36 @@ test ('objects', () => {
   eq (show (Object.create (null))) ('{}');
 });
 
+test ('sets', () => {
+  eq (show (new Set ([])))
+     (/***/'new Set ([])');
+  eq (show (new Set (['foo'])))
+     (/***/'new Set (["foo"])');
+  eq (show (new Set (['foo', 'bar'])))
+     (/***/'new Set (["foo", "bar"])');
+  eq (show (new Set (['foo', 'bar', 'baz'])))
+     (/***/'new Set (["foo", "bar", "baz"])');
+  eq (show (new Set ([new Set ([])])))
+     (/***/'new Set ([new Set ([])])');
+  eq (show (new Set ([new Set ([new Set ([])])])))
+     (/***/'new Set ([new Set ([new Set ([])])])');
+});
+
+test ('maps', () => {
+  eq (show (new Map ([])))
+     (/***/'new Map ([])');
+  eq (show (new Map ([['foo', 'foo']])))
+     (/***/'new Map ([["foo", "foo"]])');
+  eq (show (new Map ([['foo', 'foo'], ['bar', 'bar']])))
+     (/***/'new Map ([["foo", "foo"], ["bar", "bar"]])');
+  eq (show (new Map ([['foo', 'foo'], ['bar', 'bar'], ['baz', 'baz']])))
+     (/***/'new Map ([["foo", "foo"], ["bar", "bar"], ["baz", "baz"]])');
+  eq (show (new Map ([[new Map ([]), new Map ([])]])))
+     (/***/'new Map ([[new Map ([]), new Map ([])]])');
+  eq (show (new Map ([[new Map ([['kk', 'kv']]), new Map ([['vk', 'vv']])]])))
+     (/***/'new Map ([[new Map ([["kk", "kv"]]), new Map ([["vk", "vv"]])]])');
+});
+
 test ('other values', () => {
   eq (show (/def/g)) ('/def/g');
   eq (show (Math.sqrt)) ('function sqrt() { [native code] }');


### PR DESCRIPTION
Insertion order is respected, so `show (new Set ([1, 2, 3]))` ≠ `show (new Set ([3, 2, 1]))`.

Sorting would be unnecessarily restrictive: `Set a` would satisfy Showable only if `a` satisfies [Ord][1].

In various test suites we define `eq` which asserts that `show (actual)` = `show (expected)` before asserting that `equals (actual) (expected)` = `true`. We will now need to ensure that `actual` and `expected` have the same insertion order anywhere we apply `eq` to native Set or Map values.


[1]: https://github.com/fantasyland/fantasy-land#ord
