### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "overrides": [
     {
       "files": ["*.md"],
-      "globals": {"Maybe": false, "show": false}
+      "globals": {"Maybe": "readonly", "show": "readonly"}
     }
   ]
 }


### PR DESCRIPTION
Relates to sanctuary-js/sanctuary-style#33
