### PR TITLE
respect `@@show` property of non-Object objects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint.json"],
   "parserOptions": {"sourceType": "module"},
+  "rules": {
+    "eqeqeq": ["off"]
+  },
   "overrides": [
     {
       "files": ["test/**/*.js"],

--- a/index.js
+++ b/index.js
@@ -90,17 +90,14 @@ const sortedKeys = o => (Object.keys (o)).sort ();
 //. '{"x": [1, 2], "y": [3, 4], "z": [5, 6]}'
 //. ```
 const show = x => {
+  if (x === null) return 'null';
+  if (x === undefined) return 'undefined';
+  if (typeof x[$$show] === 'function') return x[$$show] ();
   if (seen.has (x)) return '<Circular>';
 
   const repr = Object.prototype.toString.call (x);
 
   switch (repr) {
-
-    case '[object Null]':
-      return 'null';
-
-    case '[object Undefined]':
-      return 'undefined';
 
     case '[object Boolean]':
       return typeof x === 'object' ?
@@ -148,12 +145,7 @@ const show = x => {
     case '[object Object]':
       seen.add (x);
       try {
-        return (
-          $$show in x &&
-          (x.constructor == null || x.constructor.prototype !== x) ?
-            x[$$show] () :
-            '{' + ((sortedKeys (x)).map (entry (x))).join (', ') + '}'
-        );
+        return '{' + ((sortedKeys (x)).map (entry (x))).join (', ') + '}';
       } finally {
         seen.delete (x);
       }

--- a/test/index.js
+++ b/test/index.js
@@ -156,5 +156,13 @@ test ('custom @@show method (prototype)', () => {
   };
   eq (show (Identity (['foo', 'bar', 'baz'])), 'Identity (["foo", "bar", "baz"])');
   eq (show (Identity ([Identity (1), Identity (2), Identity (3)])), 'Identity ([Identity (1), Identity (2), Identity (3)])');
-  eq (show (Identity.prototype), '{"@@show": <object Function>}');
+  eq (show (Identity.prototype), 'Identity (undefined)');
+});
+
+test ('custom @@show method (non-Object object)', () => {
+  function identity(x) {
+    return x;
+  }
+  identity['@@show'] = () => 'identity :: a -> a';
+  eq (show (identity), 'identity :: a -> a');
 });


### PR DESCRIPTION
This pull request simplifies the predicate for respecting a custom `@@show` method: `typeof x['@@show'] === 'function'`. Currently we only respect custom `@@show` methods of `[object Object]` objects, and we even ignore the `@@show` property of such an object if it looks as though we are showing a prototype object.
