### PR TITLE
support Symbol objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,32 @@ const $$show = '@@show';
 //  seen :: Array Any
 const seen = new WeakSet ();
 
-//  entry :: Object -> String -> String
-const entry = o => k => show (k) + ': ' + show (o[k]);
+//  comparator :: (Symbol, Symbol) -> ( -1 | 0 | +1 )
+const comparator = ({description: a}, {description: b}) => (
+  a === undefined && b === undefined ? 0 :
+  a === undefined ? -1 :
+  b === undefined ? +1 :
+  a < b ? -1 :
+  a > b ? +1 :
+  /* otherwise */ 0
+);
 
-//  sortedKeys :: Object -> Array String
-const sortedKeys = o => (Object.keys (o)).sort ();
+//  wellKnownSymbols :: Array Symbol
+const wellKnownSymbols = [
+  Symbol.asyncIterator,
+  Symbol.hasInstance,
+  Symbol.isConcatSpreadable,
+  Symbol.iterator,
+  Symbol.match,
+  Symbol.matchAll,
+  Symbol.replace,
+  Symbol.search,
+  Symbol.species,
+  Symbol.split,
+  Symbol.toPrimitive,
+  Symbol.toStringTag,
+  Symbol.unscopables,
+].filter (x => typeof x === 'symbol');
 
 //# show :: Showable a => a -> String
 //.
@@ -114,6 +135,11 @@ const show = x => {
         'new String (' + show (x.valueOf ()) + ')' :
         JSON.stringify (x);
 
+    case '[object Symbol]':
+      for (const s of wellKnownSymbols) if (s === x) return x.description;
+      if (x.description === undefined) return 'Symbol ()';
+      return 'Symbol (' + show (x.description) + ')';
+
     case '[object RegExp]':
       return x.toString ();
 
@@ -133,11 +159,18 @@ const show = x => {
     case '[object Array]':
       seen.add (x);
       try {
-        return '[' + ((x.map (show)).concat (
-          sortedKeys (x)
-          .filter (k => !(/^\d+$/.test (k)))
-          .map (entry (x))
-        )).join (', ') + ']';
+        const keys = new Set (Object.keys (x));
+        const entries = x.map ((e, index) => {
+          keys.delete (String (index));
+          return show (e);
+        });
+        for (const k of [...keys].sort ()) {
+          entries.push (show (k) + ': ' + show (x[k]));
+        }
+        for (const k of (Object.getOwnPropertySymbols (x)).sort (comparator)) {
+          entries.push ('[' + show (k) + ']: ' + show (x[k]));
+        }
+        return '[' + entries.join (', ') + ']';
       } finally {
         seen.delete (x);
       }
@@ -145,7 +178,14 @@ const show = x => {
     case '[object Object]':
       seen.add (x);
       try {
-        return '{' + ((sortedKeys (x)).map (entry (x))).join (', ') + '}';
+        const entries = [];
+        for (const k of (Object.getOwnPropertyNames (x)).sort ()) {
+          entries.push (show (k) + ': ' + show (x[k]));
+        }
+        for (const k of (Object.getOwnPropertySymbols (x)).sort (comparator)) {
+          entries.push ('[' + show (k) + ']: ' + show (x[k]));
+        }
+        return '{' + entries.join (', ') + '}';
       } finally {
         seen.delete (x);
       }

--- a/index.js
+++ b/index.js
@@ -48,8 +48,8 @@ const comparator = ({description: a}, {description: b}) => (
   /* otherwise */ 0
 );
 
-//  wellKnownSymbols :: Array Symbol
-const wellKnownSymbols = [
+//  wellKnownSymbols :: Set Symbol
+const wellKnownSymbols = new Set ([
   Symbol.asyncIterator,
   Symbol.hasInstance,
   Symbol.isConcatSpreadable,
@@ -63,7 +63,7 @@ const wellKnownSymbols = [
   Symbol.toPrimitive,
   Symbol.toStringTag,
   Symbol.unscopables,
-].filter (x => typeof x === 'symbol');
+].filter (x => typeof x === 'symbol'));
 
 //# show :: Showable a => a -> String
 //.
@@ -136,7 +136,7 @@ const show = x => {
         JSON.stringify (x);
 
     case '[object Symbol]':
-      for (const s of wellKnownSymbols) if (s === x) return x.description;
+      if (wellKnownSymbols.has (x)) return x.description;
       if (x.description === undefined) return 'Symbol ()';
       return 'Symbol (' + show (x.description) + ')';
 

--- a/test/index.js
+++ b/test/index.js
@@ -166,3 +166,47 @@ test ('custom @@show method (non-Object object)', () => {
   identity['@@show'] = () => 'identity :: a -> a';
   eq (show (identity), 'identity :: a -> a');
 });
+
+test ('well-known symbols', () => {
+  eq (show (Symbol.asyncIterator), 'Symbol.asyncIterator');
+  eq (show (Symbol.hasInstance), 'Symbol.hasInstance');
+  eq (show (Symbol.isConcatSpreadable), 'Symbol.isConcatSpreadable');
+  eq (show (Symbol.iterator), 'Symbol.iterator');
+  eq (show (Symbol.match), 'Symbol.match');
+  eq (show (Symbol.matchAll), 'Symbol.matchAll');
+  eq (show (Symbol.replace), 'Symbol.replace');
+  eq (show (Symbol.search), 'Symbol.search');
+  eq (show (Symbol.species), 'Symbol.species');
+  eq (show (Symbol.split), 'Symbol.split');
+  eq (show (Symbol.toPrimitive), 'Symbol.toPrimitive');
+  eq (show (Symbol.toStringTag), 'Symbol.toStringTag');
+  eq (show (Symbol.unscopables), 'Symbol.unscopables');
+});
+
+test ('private symbols', () => {
+  eq (show (Symbol ('x')), 'Symbol ("x")');
+  eq (show (Symbol ('')), 'Symbol ("")');
+  eq (show (Symbol ()), 'Symbol ()');
+});
+
+test ('globally accessible symbols', () => {
+  eq (show (Symbol.for ('x')), 'Symbol ("x")');
+});
+
+test ('object property symbols', () => {
+  eq (show ({[Symbol ()]: 0, [Symbol ()]: 0}), '{[Symbol ()]: 0, [Symbol ()]: 0}');
+  eq (show ({[Symbol ()]: 0, [Symbol ('')]: 0}), '{[Symbol ()]: 0, [Symbol ("")]: 0}');
+  eq (show ({[Symbol ('')]: 0, [Symbol ()]: 0}), '{[Symbol ()]: 0, [Symbol ("")]: 0}');
+  eq (show ({[Symbol ('x')]: 0, [Symbol ('y')]: 0}), '{[Symbol ("x")]: 0, [Symbol ("y")]: 0}');
+  eq (show ({[Symbol ('y')]: 0, [Symbol ('x')]: 0}), '{[Symbol ("x")]: 0, [Symbol ("y")]: 0}');
+  eq (show ({[Symbol ('x')]: 0, [Symbol ('x')]: 0}), '{[Symbol ("x")]: 0, [Symbol ("x")]: 0}');
+  eq (show ({x: 0, [Symbol ('x')]: 0}), '{"x": 0, [Symbol ("x")]: 0}');
+});
+
+test ('array property symbols', () => {
+  const xs = ['foo', 'bar', 'baz'];
+  xs.z = 0;
+  xs[Symbol ('y')] = 0;
+  xs[Symbol ('x')] = 0;
+  eq (show (xs), '["foo", "bar", "baz", "z": 0, [Symbol ("x")]: 0, [Symbol ("y")]: 0]');
+});


### PR DESCRIPTION
This pull request changes the way Symbol objects are shown:

| Expression                | Previously gave…      | Now gives…            |
|:------------------------- |:--------------------- |:--------------------- |
| `show (Symbol.iterator)`  | `'<object Symbol>'`   | `'Symbol.iterator'`   |
| `show (Symbol ())`        | `'<object Symbol>'`   | `'Symbol ()'`         |
| `show (Symbol ('x'))`     | `'<object Symbol>'`   | `'Symbol ("x")'`      |
| `show (Symbol.for ('x'))` | `'<object Symbol>'`   | `'Symbol ("x")'` :\   |

Additionally, `Array#@@show` and `Object#@@show` now include symbol properties (see [`Object.getOwnPropertySymbols`][1]).


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
